### PR TITLE
Bugfix: Clicking on search results should scroll to that reg

### DIFF
--- a/src/pages/Search.js
+++ b/src/pages/Search.js
@@ -103,7 +103,7 @@ function Search() {
           {regulationsToShow.map((regulation) => (
             <li key={regulation.item.id}>
               <span className="anchor" id={regulation.item.id}/>
-              <Link to={'/#' + regulation.item.id}>{regulation.item.id}</Link>{') '}
+              <a href={'/#' + regulation.item.id}>{regulation.item.id}</a>{') '}
               {regulation.item.label && <span className="tag">{regulation.item.label}</span>}
               <span dangerouslySetInnerHTML={{__html: regulation.highlight || regulation.item.description}} />
             </li>

--- a/src/pages/Search.js
+++ b/src/pages/Search.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Link, useLocation, useHistory } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import flatten from 'lodash.flatten'
 import {compare as almphanumbericCompare} from 'alphanumeric-sort'
 import Fuse from 'fuse.js'


### PR DESCRIPTION
This fix is nasty :/

| Before | After |
| --- | --- |
|  ![before](https://github.com/coder13/wcaregs/assets/24919355/80858040-ae82-40c3-80be-4520ab3ddc92) | ![after](https://github.com/coder13/wcaregs/assets/24919355/be21c305-1318-45ea-9b66-82ff6b795405) |